### PR TITLE
unpin lodash version

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "webpack": "1.12.13"
   },
   "dependencies": {
-    "lodash": "4.2.1"
+    "lodash": "^4.2.1"
   },
   "npmName": "map2tree",
   "npmFileMap": [


### PR DESCRIPTION
It looks like the lodash version was pinned, and npm is complaining due to a security vulnerability:

npm WARN notice [SECURITY] lodash has and 1 low vulnerability. Go here for more details: https://nodesecurity.io/advisories?search=lodash&version=4.11.1 - Run `npm i npm@latest -g` to upgrade your npm version, and then `npm audit` to get more info.

lodash <4.17.5 is affected, but I didn't want to change the minimum requirement, since people with a higher version will be able to use that, and people who haven't upgraded yet won't have duplicate dependencies.
Feel free to change the version number, but since the vulnerable functions ('defaultsDeep', 'merge', and 'mergeWith') are not used here, I didn't think it was necessary.